### PR TITLE
[#55] Fix JDK8 problems and problems with existing MANIFEST.MF files

### DIFF
--- a/core/src/main/java/org/moditect/commands/AddModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/AddModuleInfo.java
@@ -23,6 +23,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.Attributes;
@@ -106,8 +107,8 @@ public class AddModuleInfo {
                    manifest.getMainAttributes().put( Attributes.Name.MANIFEST_VERSION, "1.0" );
                }
 
-               manifest.getMainAttributes().put( Attributes.Name.MULTI_RELEASE, "true" );
-               try (OutputStream manifestOs = Files.newOutputStream( manifestPath )) {
+               manifest.getMainAttributes().put( new Attributes.Name("Multi-Release"), "true" );
+               try (OutputStream manifestOs = Files.newOutputStream( manifestPath, StandardOpenOption.TRUNCATE_EXISTING )) {
                    manifest.write( manifestOs );
                }
            }


### PR DESCRIPTION
Replace use of MULTI_RELEASE manifest attribute name field which is only available in Java 9 and fix problems with JARs when manifest already exists for #55 