### PR TITLE
Option ignoreSigningInformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ will be used when creating the runtime image (optional; if not given the JDK run
 current build will be used). Must unambiguously identify one toolchain entry of type `jdk`
 that matches all given requirements in its `<provides>` configuration. This can be used for
 creating runtime images on one platform (e.g. OS X) while targeting another (e.g. Linux).
+* `ignoreSigningInformation`: Suppresses a fatal error when signed modular JARs are linked
+in the runtime image. The signature-related files of the signed modular JARs aren’t copied 
+to the runtime image.
 
 Once the image has been created, it can be executed by running:
 

--- a/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
+++ b/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
@@ -36,6 +36,7 @@ public class CreateRuntimeImage {
     private final Set<Path> modulePath;
     private final List<String> modules;
     private final Path outputDirectory;
+    private boolean ignoreSigningInformation;
     private final String launcher;
     private final Log log;
     private final Integer compression;
@@ -43,10 +44,11 @@ public class CreateRuntimeImage {
     private final List<String> excludeResourcesPatterns;
 
     public CreateRuntimeImage(Set<Path> modulePath, List<String> modules, String launcherName, String launcherModule,
-            Path outputDirectory, Integer compression, boolean stripDebug, List<String> excludeResourcesPatterns, Log log) {
+                              Path outputDirectory, Integer compression, boolean stripDebug, boolean ignoreSigningInformation, List<String> excludeResourcesPatterns, Log log) {
         this.modulePath = ( modulePath != null ? modulePath : Collections.emptySet() );
         this.modules = getModules( modules );
         this.outputDirectory = outputDirectory;
+        this.ignoreSigningInformation = ignoreSigningInformation;
         this.launcher = launcherName != null && launcherModule != null ? launcherName + "=" + launcherModule : null;
         this.compression = compression;
         this.stripDebug = stripDebug;
@@ -97,6 +99,10 @@ public class CreateRuntimeImage {
 
         if ( stripDebug ) {
             command.add( "--strip-debug" );
+        }
+
+        if (ignoreSigningInformation) {
+            command.add( "--ignore-signing-information" );
         }
 
         if ( !excludeResourcesPatterns.isEmpty() ) {

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
@@ -74,6 +74,9 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
     @Parameter
     List<String> excludedResources;
 
+    @Parameter(property = "ignoreSigningInformation", defaultValue = "false")
+    private boolean ignoreSigningInformation;
+
 //    @Parameter(property = "moditect.artifact")
 //    private String artifactOverride;
 //
@@ -91,8 +94,8 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
         Path jmodsDir = getJModsDir();
 
         Set<Path> effectiveModulePath = this.modulePath.stream()
-            .map( File::toPath )
-            .collect( Collectors.toSet() );
+                .map( File::toPath )
+                .collect( Collectors.toSet() );
 
         effectiveModulePath.add( jmodsDir );
 
@@ -104,10 +107,11 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
                 outputDirectory.toPath(),
                 compression,
                 stripDebug,
+                ignoreSigningInformation,
                 getExcludeResourcesPatterns(),
                 new MojoLog( getLog() )
         )
-        .run();
+                .run();
     }
 
     /**
@@ -148,7 +152,7 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
             if ( keyAndValue.length != 2 ) {
                 throw new MojoExecutionException(
                         "Toolchain requirements must be given in the form 'key1=value1,key2=value2,...'." +
-                        "Given value '" + baseJdk + "' doesn't match this pattern." );
+                                "Given value '" + baseJdk + "' doesn't match this pattern." );
             }
 
             toolChainRequirements.put( keyAndValue[0].trim(), keyAndValue[1].trim() );


### PR DESCRIPTION
Option  added for create-runtime-image goal. For suppresses a fatal error when signed modular JARs are linked in the runtime image. The signature-related files of the signed modular JARs aren’t copied to the runtime image.

Updated README.MD