### PR TITLE
Allow module-info.class overwrite

### DIFF
--- a/core/src/main/java/org/moditect/commands/AddModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/AddModuleInfo.java
@@ -109,12 +109,18 @@ public class AddModuleInfo {
 
        try (FileSystem zipfs = FileSystems.newFileSystem( uri, env ) ) {
            if (jvmVersion == null) {
-               Files.write( zipfs.getPath( "module-info.class" ), clazz );
+               Files.write( zipfs.getPath( "module-info.class" ), clazz,
+                 StandardOpenOption.CREATE,
+                 StandardOpenOption.WRITE,
+                 StandardOpenOption.TRUNCATE_EXISTING );
            }
            else {
                Path path = zipfs.getPath( "META-INF/versions", jvmVersion.toString(), "module-info.class" );
                Files.createDirectories( path.getParent() );
-               Files.write( path, clazz );
+               Files.write( path, clazz,
+                 StandardOpenOption.CREATE,
+                 StandardOpenOption.WRITE,
+                 StandardOpenOption.TRUNCATE_EXISTING );
 
                Path manifestPath = zipfs.getPath( "META-INF/MANIFEST.MF" );
                Manifest manifest;


### PR DESCRIPTION
The plugin throws an exception when adding a module-info.class to a jar already containing one.
This is related to [JDK-8034773](https://bugs.openjdk.java.net/browse/JDK-8034773). It may only happen when running the plugin with java 8 since this bug was apparently fixed in Java 9. This PR explicitly sets the TRUNCATE_EXISTING option as a workaround.