### PR TITLE
handle originalModuleName for invalid module names

### DIFF
--- a/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
@@ -18,8 +18,6 @@ package org.moditect.commands;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.lang.module.ModuleDescriptor;
-import java.lang.module.ModuleFinder;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -116,7 +114,7 @@ public class GenerateModuleInfo {
         }
     }
 
-    private static Path createCopyWithAutoModuleNameManifestHeader(Path workingDirectory, Path inputJar, String moduleName) {
+    public static Path createCopyWithAutoModuleNameManifestHeader(Path workingDirectory, Path inputJar, String moduleName) {
         if ( moduleName == null ) {
             throw new IllegalArgumentException( "No automatic name can be derived for the JAR " + inputJar + ", hence an explicit module name is required" );
         }
@@ -342,14 +340,9 @@ public class GenerateModuleInfo {
                     modules.append( "," );
                     modulePath.append( File.pathSeparator );
                 }
-                ModuleDescriptor descriptor = ModuleFinder.of( dependency.getPath() )
-                        .findAll()
-                        .iterator()
-                        .next()
-                        .descriptor();
-
-                modules.append( descriptor.name() );
-                optionalityPerModule.put( descriptor.name(), dependency.isOptional() );
+                String moduleName = DependencyDescriptor.getAutoModuleNameFromInputJar(dependency.getPath(), dependency.getAssignedModuleName());
+                modules.append( moduleName );
+                optionalityPerModule.put( moduleName, dependency.isOptional() );
                 modulePath.append( dependency.getPath() );
             }
 

--- a/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
@@ -18,7 +18,6 @@ package org.moditect.commands;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.lang.module.FindException;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleFinder;
 import java.net.URI;
@@ -79,7 +78,7 @@ public class GenerateModuleInfo {
     private ToolProvider jdeps;
 
     public GenerateModuleInfo(Path inputJar, String moduleName, boolean open, Set<DependencyDescriptor> dependencies, List<PackageNamePattern> exportPatterns, List<PackageNamePattern> opensPatterns, List<DependencePattern> requiresPatterns, Path workingDirectory, Path outputDirectory, Set<String> uses, boolean addServiceUses, List<String> jdepsExtraArgs, Log log) {
-        String autoModuleNameForInputJar = getAutoModuleNameFromInputJar( inputJar );
+        String autoModuleNameForInputJar = DependencyDescriptor.getAutoModuleNameFromInputJar(inputJar, null);
 
         // if no valid auto module name can be derived for the input JAR, create a copy of it and
         // inject the target module name into the manifest ("Automatic-Module-Name"), as otherwise
@@ -114,24 +113,6 @@ public class GenerateModuleInfo {
         }
         else {
             throw new RuntimeException( "jdeps tool not found" );
-        }
-    }
-
-    private static String getAutoModuleNameFromInputJar(Path inputJar) {
-        try {
-            return ModuleFinder.of( inputJar )
-                    .findAll()
-                    .iterator()
-                    .next()
-                    .descriptor()
-                    .name();
-        }
-        catch (FindException e) {
-            if ( e.getCause() != null && e.getCause().getMessage().contains( "Invalid module name" ) ) {
-                return null;
-            }
-
-            throw e;
         }
     }
 

--- a/core/src/main/java/org/moditect/model/DependencyDescriptor.java
+++ b/core/src/main/java/org/moditect/model/DependencyDescriptor.java
@@ -37,7 +37,10 @@ public class DependencyDescriptor {
     public DependencyDescriptor(Path path, boolean optional, String assignedModuleName) {
         this.path = path;
         this.optional = optional;
-        this.originalModuleName = getAutoModuleNameFromInputJar(path, "<invalid-module-name>");
+        this.originalModuleName = getAutoModuleNameFromInputJar(path, assignedModuleName);
+        if(this.originalModuleName == null) {
+            throw new IllegalArgumentException("No assignedModuleName provided for jar with invalid module name: " + path);
+        }
         this.assignedModuleName = assignedModuleName;
     }
 

--- a/core/src/main/java/org/moditect/model/DependencyDescriptor.java
+++ b/core/src/main/java/org/moditect/model/DependencyDescriptor.java
@@ -37,11 +37,11 @@ public class DependencyDescriptor {
     public DependencyDescriptor(Path path, boolean optional, String assignedModuleName) {
         this.path = path;
         this.optional = optional;
-        this.originalModuleName = getOriginalModuleNameOf(path);
+        this.originalModuleName = getAutoModuleNameFromInputJar(path, "<invalid-module-name>");
         this.assignedModuleName = assignedModuleName;
     }
 
-    private static String getOriginalModuleNameOf(Path path) {
+    public static String getAutoModuleNameFromInputJar(Path path, String invalidModuleName) {
         try {
             return ModuleFinder.of( path )
                     .findAll()
@@ -52,7 +52,7 @@ public class DependencyDescriptor {
         }
         catch (FindException e) {
             if ( e.getCause() != null && e.getCause().getMessage().contains( "Invalid module name" ) ) {
-                return "<invalid-module-name>";
+                return invalidModuleName;
             }
             throw e;
         }

--- a/core/src/main/java/org/moditect/model/DependencyDescriptor.java
+++ b/core/src/main/java/org/moditect/model/DependencyDescriptor.java
@@ -15,6 +15,7 @@
  */
 package org.moditect.model;
 
+import java.lang.module.FindException;
 import java.lang.module.ModuleFinder;
 import java.nio.file.Path;
 
@@ -36,13 +37,25 @@ public class DependencyDescriptor {
     public DependencyDescriptor(Path path, boolean optional, String assignedModuleName) {
         this.path = path;
         this.optional = optional;
-        this.originalModuleName = ModuleFinder.of( path )
-                .findAll()
-                .iterator()
-                .next()
-                .descriptor()
-                .name();
+        this.originalModuleName = getOriginalModuleNameOf(path);
         this.assignedModuleName = assignedModuleName;
+    }
+
+    private static String getOriginalModuleNameOf(Path path) {
+        try {
+            return ModuleFinder.of( path )
+                    .findAll()
+                    .iterator()
+                    .next()
+                    .descriptor()
+                    .name();
+        }
+        catch (FindException e) {
+            if ( e.getCause() != null && e.getCause().getMessage().contains( "Invalid module name" ) ) {
+                return "<invalid-module-name>";
+            }
+            throw e;
+        }
     }
 
     public Path getPath() {


### PR DESCRIPTION
Hi, @gunnarmorling  ,

As you already know, I'm [working on a Gradle plugin](https://github.com/beryx/badass-jar-plugin/issues/1#issuecomment-451301349) for ModiTect.

Gradle has a different artifact resolution approach than Maven. That's why some issues may affect the Gradle plugin but not the Maven plugin. Such an issue is caused by modules with an invalid auto module name (e.g. `netty-transport-native-epoll-4.1.15.Final.jar`).

You [addressed this problem](https://github.com/moditect/moditect/blob/2e658d1c5be25707f9191695f957c5b1428a86ea/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java#L121-L135) in _GenerateModuleInfo_. This PR provides provides a similar fix needed by the Gradle plugin. It concerns the `originalModuleName` of a _DependencyDescriptor_.
