### PR TITLE
#Issue 81 - Possibility to skip plugin execution

### DIFF
--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
@@ -92,6 +92,9 @@ public class AddModuleInfoMojo extends AbstractMojo {
     @Parameter(property = "overwriteExistingFiles", defaultValue = "false")
     private boolean overwriteExistingFiles;
 
+    @Parameter(property = "moditect.skip", defaultValue = "false")
+    private boolean skip;
+
     @Parameter
     private MainModuleConfiguration module;
 
@@ -103,6 +106,18 @@ public class AddModuleInfoMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+    	// Check if this plugin should be skipped
+    	if (skip) {
+    		getLog().debug("Mojo 'add-module-info' skipped by configuration");
+    		return;
+    	}
+    	// Don't try to run this plugin, when packaging type is 'pom'
+    	// (may be better to only run it on specific packaging types, like 'jar')
+//    	if (project.getModel().getPackaging().equalsIgnoreCase("pom")) {
+//    		getLog().debug("Mojo 'add-module-info' not executed on packaging type '"+project.getModel().getPackaging()+"'");
+//    		return;
+//    	}
+    	
         Path outputPath = outputDirectory.toPath();
 
         createDirectories();

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
@@ -113,10 +113,10 @@ public class AddModuleInfoMojo extends AbstractMojo {
     	}
     	// Don't try to run this plugin, when packaging type is 'pom'
     	// (may be better to only run it on specific packaging types, like 'jar')
-//    	if (project.getModel().getPackaging().equalsIgnoreCase("pom")) {
-//    		getLog().debug("Mojo 'add-module-info' not executed on packaging type '"+project.getModel().getPackaging()+"'");
-//    		return;
-//    	}
+    	if (project.getModel().getPackaging().equalsIgnoreCase("pom")) {
+    		getLog().debug("Mojo 'add-module-info' not executed on packaging type '"+project.getModel().getPackaging()+"'");
+    		return;
+    	}
     	
         Path outputPath = outputDirectory.toPath();
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/GenerateModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/GenerateModuleInfoMojo.java
@@ -91,9 +91,24 @@ public class GenerateModuleInfoMojo extends AbstractMojo {
     @Parameter(property = "moditect.addServiceUses", defaultValue = "false")
     private boolean addServiceUsesOverride;
 
+    @Parameter(property = "moditect.skip", defaultValue = "false")
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        createDirectories();
+    	// Check if this plugin should be skipped
+    	if (skip) {
+    		getLog().debug("Mojo 'generate-module-info' skipped by configuration");
+    		return;
+    	}
+    	// Don't try to run this plugin, when packaging type is 'pom'
+    	// (may be better to only run it on specific packaging types, like 'jar')
+    	if (project.getModel().getPackaging().equalsIgnoreCase("pom")) {
+    		getLog().debug("Mojo 'generate-module-info' not executed on packaging type '"+project.getModel().getPackaging()+"'");
+    		return;
+    	}
+
+    	createDirectories();
 
         ArtifactResolutionHelper artifactResolutionHelper = new ArtifactResolutionHelper( repoSystem, repoSession, remoteRepos );
         ModuleInfoGenerator moduleInfoGenerator = new ModuleInfoGenerator(


### PR DESCRIPTION
Okay, that wasn't that hard :)

Added a 'moditect.skip' property to AddModuleInfoMojo and GenerateModuleInfoMojo.
Also plugin is not executed, when packaging type of project is 'pom'.
