### PR TITLE
#104 Support multiple launchers (entry points)

### DIFF
--- a/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
+++ b/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
@@ -37,19 +37,25 @@ public class CreateRuntimeImage {
     private final List<String> modules;
     private final Path outputDirectory;
     private boolean ignoreSigningInformation;
-    private final String launcher;
+    private final List<String> launchers = new ArrayList<>();
     private final Log log;
     private final Integer compression;
     private final boolean stripDebug;
     private final List<String> excludeResourcesPatterns;
 
-    public CreateRuntimeImage(Set<Path> modulePath, List<String> modules, String launcherName, String launcherModule,
+    public CreateRuntimeImage(Set<Path> modulePath, List<String> modules, List<String> launcherNames, List<String> launcherModules,
                               Path outputDirectory, Integer compression, boolean stripDebug, boolean ignoreSigningInformation, List<String> excludeResourcesPatterns, Log log) {
         this.modulePath = ( modulePath != null ? modulePath : Collections.emptySet() );
         this.modules = getModules( modules );
         this.outputDirectory = outputDirectory;
         this.ignoreSigningInformation = ignoreSigningInformation;
-        this.launcher = launcherName != null && launcherModule != null ? launcherName + "=" + launcherModule : null;
+        
+        if (launcherNames != null && launcherModules != null) {
+          for (int i=0; i < launcherNames.size() && i < launcherModules.size(); i++) {
+            this.launchers.add(launcherNames.get(i)  + "=" + launcherModules.get(i));
+          }
+        }
+        
         this.compression = compression;
         this.stripDebug = stripDebug;
         this.excludeResourcesPatterns = excludeResourcesPatterns;
@@ -87,7 +93,7 @@ public class CreateRuntimeImage {
         command.add( "--output" );
         command.add( outputDirectory.toString() );
 
-        if ( launcher != null ) {
+        for (String launcher : launchers) {
             command.add( "--launcher" );
             command.add( launcher );
         }

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
@@ -63,7 +63,7 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
     private List<String> modules;
 
     @Parameter
-    private Launcher launcher;
+    private List<Launcher> launchers;
 
     @Parameter
     private Integer compression;
@@ -98,12 +98,24 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
                 .collect( Collectors.toSet() );
 
         effectiveModulePath.add( jmodsDir );
+        
+        List<String> launcherNames = launchers.stream().map(Launcher::getName).collect(Collectors.toList());
+        
+        List<String> launcherModules = launchers.stream().map(l -> {
+          StringBuilder sb = new StringBuilder(l.getModule());
+          String mainClass = l.getMainClass();
+          if (mainClass != null) {
+            sb.append("/");
+            sb.append(mainClass);
+          }
+          return sb.toString();
+        }).collect(Collectors.toList());
 
         new CreateRuntimeImage(
                 effectiveModulePath,
                 modules,
-                launcher != null ? launcher.getName() : null,
-                launcher != null ? launcher.getModule() : null,
+                launcherNames,
+                launcherModules,
                 outputDirectory.toPath(),
                 compression,
                 stripDebug,

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/model/Launcher.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/model/Launcher.java
@@ -22,22 +22,31 @@ package org.moditect.mavenplugin.image.model;
  */
 public class Launcher {
 
-    private String name;
+    private String mainClass;
     private String module;
+    private String name;
 
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
+    public String getMainClass() {
+      return mainClass;
     }
 
     public String getModule() {
         return module;
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public void setMainClass(String mainClass) {
+      this.mainClass = mainClass;
+    }
+
     public void setModule(String module) {
         this.module = module;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 }


### PR DESCRIPTION
Plugin configuration changed to support multiple instances of launcher. Also, field mainClass is added to the launcher.

Example:
```xml
<launchers>
	<launcher>
		<name>xmldiff</name>
		<module>diff.merge</module>
		<mainClass>io.fixprotocol.xml.XmlDiff</mainClass>
	</launcher>
	<launcher>
		<name>xmlmerge</name>
		<module>diff.merge</module>
		<mainClass>io.fixprotocol.xml.XmlMerge</mainClass>
	</launcher>
</launchers>
```
This configuration adds these parameters to the jlink command line:
`--launcher xmldiff=diff.merge/io.fixprotocol.xml.XmlDiff --launcher xmlmerge=diff.merge/io.fixprotocol.xml.XmlMerge`