### PR TITLE
Update trigger workflow with version handling

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -84,7 +84,9 @@ jobs:
           VERSION=${{ github.event.inputs.version }}
           echo "Releasing $VERSION from $BRANCH branch"
           git checkout $BRANCH
-          ./mvnw -B versions:set versions:commit -DnewVersion=$VERSION
+          ./mvnw -B versions:set -DnewVersion=$VERSION -f parent/pom.xml -pl :moditect-parent
+          ./mvnw -B versions:update-child-modules
+          ./mvnw -B versions:commit
           git config --global user.email "moditect-release-bot@moditect.org"
           git config --global user.name "moditect-release-bot"
           git commit -a -m "Releasing version $VERSION"


### PR DESCRIPTION
The root pom (build) is not the parent pom, this means using versions:set
won't work as expected. Instead we must
1. set the version on parent/pom.xml
2. update all children poms
3. commit changes