### PR TITLE
Make `AddModuleInfoMojo.jvmVersion` non-readonly

### DIFF
--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
@@ -98,7 +98,7 @@ public class AddModuleInfoMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.version}", readonly = true, required = true)
     private String version;
 
-    @Parameter(property = "moditect.jvmVersion", readonly = true)
+    @Parameter(property = "moditect.jvmVersion")
     private String jvmVersion;
 
     @Parameter(readonly = true, defaultValue = "${project.build.directory}/moditect")


### PR DESCRIPTION
Fixes #75 (see last comment there)

In the pull request which initially added this parameter (#54) it was not mentioned why the parameter has `readonly = true`, so I assume it was a copy and paste error.