### PR TITLE
[TESTS] add snakeyaml + toolchains integration test

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -36,5 +36,6 @@
         <module>undertow</module>
         <module>vert.x</module>
         <module>hibernate-validator</module>
+        <module>snakeyaml</module>
     </modules>
 </project>

--- a/integrationtest/snakeyaml/pom.xml
+++ b/integrationtest/snakeyaml/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2017 - 2023 The ModiTect authors
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-integrationtest-parent</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>moditect-integrationtest-snakeyaml</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+    <properties>
+        <snakeyaml.version>1.33</snakeyaml.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.33</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <toolchains>
+                        <!-- this project needs a JDK toolchain, version 8 -->
+                        <jdk>
+                            <version>8</version>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-module-info-to-dependencies</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/modules</outputDirectory>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+
+                            <modules>
+                                <module>
+                                    <artifact>
+                                        <groupId>org.yaml</groupId>
+                                        <artifactId>snakeyaml</artifactId>
+                                        <version>${snakeyaml.version}</version>
+                                    </artifact>
+
+                                    <moduleInfo>
+                                        <name>org.yaml.snakeyaml</name>
+                                        <requires>
+                                            java.logging;
+                                            transitive java.desktop;
+                                        </requires>
+                                        <exports>
+                                            org.yaml.snakeyaml;
+                                            org.yaml.snakeyaml.composer;
+                                            org.yaml.snakeyaml.constructor;
+                                            org.yaml.snakeyaml.emitter;
+                                            org.yaml.snakeyaml.env;
+                                            org.yaml.snakeyaml.error;
+                                            org.yaml.snakeyaml.events;
+                                            org.yaml.snakeyaml.extensions.compactnotation;
+                                            org.yaml.snakeyaml.external.biz.base64Coder;
+                                            org.yaml.snakeyaml.external.com.google.gdata.util.common.base;
+                                            org.yaml.snakeyaml.introspector;
+                                            org.yaml.snakeyaml.nodes;
+                                            org.yaml.snakeyaml.parser;
+                                            org.yaml.snakeyaml.reader;
+                                            org.yaml.snakeyaml.representer;
+                                            org.yaml.snakeyaml.resolver;
+                                            org.yaml.snakeyaml.scanner;
+                                            org.yaml.snakeyaml.serializer;
+                                            org.yaml.snakeyaml.tokens;
+                                            org.yaml.snakeyaml.util;
+                                        </exports>
+                                    </moduleInfo>
+                                </module>
+                            </modules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    
+</project>


### PR DESCRIPTION
- [ ] Needs a toolchain in github workflows


Will throw this exception on current HEAD and any released version:

```
[ERROR] Failed to execute goal org.moditect:moditect-maven-plugin:1.2.0-SNAPSHOT:add-module-info (add-module-info-to-dependencies) on project moditect-integrationtest-snakeyaml: Execution add-module-info-to-dependencies of goal org.moditect:moditect-maven-plugin:1.2.0-SNAPSHOT:add-module-info failed.: NullPointerException -> [Help 1]org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.moditect:moditect-maven-plugin:1.2.0-SNAPSHOT:add-module-info (add-module-info-to-dependencies) on project moditect-integrationtest-snakeyaml: Execution add-module-info-to-dependencies of goal org.moditect:moditect-maven-plugin:1.2.0-SNAPSHOT:add-module-info failed.
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:333)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at io.takari.maven.builder.smart.SmartBuilderImpl.buildProject (SmartBuilderImpl.java:209)
    at io.takari.maven.builder.smart.SmartBuilderImpl$ProjectBuildTask.run (SmartBuilderImpl.java:81)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:515)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    at java.lang.Thread.run (Thread.java:866)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution add-module-info-to-dependencies of goal org.moditect:moditect-maven-plugin:1.2.0-SNAPSHOT:add-module-info failed.
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:133)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at io.takari.maven.builder.smart.SmartBuilderImpl.buildProject (SmartBuilderImpl.java:209)
    at io.takari.maven.builder.smart.SmartBuilderImpl$ProjectBuildTask.run (SmartBuilderImpl.java:81)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:515)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    at java.lang.Thread.run (Thread.java:866)
Caused by: java.lang.NullPointerException
    at java.util.Objects.requireNonNull (Objects.java:221)
    at org.apache.maven.project.SnapshotModelCache.<init> (SnapshotModelCache.java:32)
    at org.apache.maven.project.SnapshotModelCacheFactory.createCache (SnapshotModelCacheFactory.java:57)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom (DefaultArtifactDescriptorReader.java:269)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor (DefaultArtifactDescriptorReader.java:175)
    at org.eclipse.aether.internal.impl.collect.DependencyCollectorDelegate.collectDependencies (DependencyCollectorDelegate.java:179)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.collectDependencies (DefaultDependencyCollector.java:87)
    at org.eclipse.aether.internal.impl.DefaultRepositorySystem.collectDependencies (DefaultRepositorySystem.java:306)
    at org.moditect.mavenplugin.util.ArtifactResolutionHelper.getCompilationDependencies (ArtifactResolutionHelper.java:96)
    at org.moditect.mavenplugin.generate.ModuleInfoGenerator.getDependencies (ModuleInfoGenerator.java:169)
    at org.moditect.mavenplugin.generate.ModuleInfoGenerator.generateModuleInfo (ModuleInfoGenerator.java:85)
    at org.moditect.mavenplugin.add.AddModuleInfoMojo.getModuleInfoSource (AddModuleInfoMojo.java:372)
    at org.moditect.mavenplugin.add.AddModuleInfoMojo.execute (AddModuleInfoMojo.java:190)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at io.takari.maven.builder.smart.SmartBuilderImpl.buildProject (SmartBuilderImpl.java:209)
    at io.takari.maven.builder.smart.SmartBuilderImpl$ProjectBuildTask.run (SmartBuilderImpl.java:81)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:515)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    at java.lang.Thread.run (Thread.java:866)
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -r
```