### PR TITLE
License and Maven update

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.7/apache-maven-3.8.7-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,9 +3,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,19 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -27,7 +19,6 @@
     </parent>
 
     <artifactId>moditect</artifactId>
-    <packaging>jar</packaging>
     <name>ModiTect</name>
     <url>https://github.com/moditect/moditect</url>
     <description>Module system tooling</description>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,9 +33,9 @@
             <artifactId>asm</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.beust</groupId>
+            <groupId>org.jcommander</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.82</version>
+            <version>1.83</version>
         </dependency>
 
         <!-- Test -->

--- a/core/src/main/java/org/moditect/Moditect.java
+++ b/core/src/main/java/org/moditect/Moditect.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect;
 

--- a/core/src/main/java/org/moditect/Moditect.java
+++ b/core/src/main/java/org/moditect/Moditect.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect;
 

--- a/core/src/main/java/org/moditect/commands/AddModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/AddModuleInfo.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/commands/AddModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/AddModuleInfo.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
+++ b/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
+++ b/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
+++ b/core/src/main/java/org/moditect/commands/GenerateModuleInfo.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/commands/GenerateModuleList.java
+++ b/core/src/main/java/org/moditect/commands/GenerateModuleList.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/commands/GenerateModuleList.java
+++ b/core/src/main/java/org/moditect/commands/GenerateModuleList.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.commands;
 

--- a/core/src/main/java/org/moditect/internal/analyzer/ServiceLoaderUseScanner.java
+++ b/core/src/main/java/org/moditect/internal/analyzer/ServiceLoaderUseScanner.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.analyzer;
 

--- a/core/src/main/java/org/moditect/internal/analyzer/ServiceLoaderUseScanner.java
+++ b/core/src/main/java/org/moditect/internal/analyzer/ServiceLoaderUseScanner.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.analyzer;
 

--- a/core/src/main/java/org/moditect/internal/command/LogWriter.java
+++ b/core/src/main/java/org/moditect/internal/command/LogWriter.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.command;
 

--- a/core/src/main/java/org/moditect/internal/command/LogWriter.java
+++ b/core/src/main/java/org/moditect/internal/command/LogWriter.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.command;
 

--- a/core/src/main/java/org/moditect/internal/command/ProcessExecutor.java
+++ b/core/src/main/java/org/moditect/internal/command/ProcessExecutor.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.command;
 

--- a/core/src/main/java/org/moditect/internal/command/ProcessExecutor.java
+++ b/core/src/main/java/org/moditect/internal/command/ProcessExecutor.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.command;
 

--- a/core/src/main/java/org/moditect/internal/compiler/ModuleInfoCompiler.java
+++ b/core/src/main/java/org/moditect/internal/compiler/ModuleInfoCompiler.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.compiler;
 

--- a/core/src/main/java/org/moditect/internal/compiler/ModuleInfoCompiler.java
+++ b/core/src/main/java/org/moditect/internal/compiler/ModuleInfoCompiler.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.compiler;
 

--- a/core/src/main/java/org/moditect/internal/parser/JavaVersionHelper.java
+++ b/core/src/main/java/org/moditect/internal/parser/JavaVersionHelper.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.parser;
 

--- a/core/src/main/java/org/moditect/internal/parser/JavaVersionHelper.java
+++ b/core/src/main/java/org/moditect/internal/parser/JavaVersionHelper.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.parser;
 

--- a/core/src/main/java/org/moditect/internal/parser/JdepsExtraArgsExtractor.java
+++ b/core/src/main/java/org/moditect/internal/parser/JdepsExtraArgsExtractor.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.parser;
 

--- a/core/src/main/java/org/moditect/internal/parser/JdepsExtraArgsExtractor.java
+++ b/core/src/main/java/org/moditect/internal/parser/JdepsExtraArgsExtractor.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.parser;
 

--- a/core/src/main/java/org/moditect/model/DependencePattern.java
+++ b/core/src/main/java/org/moditect/model/DependencePattern.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/DependencePattern.java
+++ b/core/src/main/java/org/moditect/model/DependencePattern.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/DependencyDescriptor.java
+++ b/core/src/main/java/org/moditect/model/DependencyDescriptor.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/DependencyDescriptor.java
+++ b/core/src/main/java/org/moditect/model/DependencyDescriptor.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/GeneratedModuleInfo.java
+++ b/core/src/main/java/org/moditect/model/GeneratedModuleInfo.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/GeneratedModuleInfo.java
+++ b/core/src/main/java/org/moditect/model/GeneratedModuleInfo.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/JarInclusionPolicy.java
+++ b/core/src/main/java/org/moditect/model/JarInclusionPolicy.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/JarInclusionPolicy.java
+++ b/core/src/main/java/org/moditect/model/JarInclusionPolicy.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/PackageNamePattern.java
+++ b/core/src/main/java/org/moditect/model/PackageNamePattern.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/PackageNamePattern.java
+++ b/core/src/main/java/org/moditect/model/PackageNamePattern.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/Version.java
+++ b/core/src/main/java/org/moditect/model/Version.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/model/Version.java
+++ b/core/src/main/java/org/moditect/model/Version.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.model;
 

--- a/core/src/main/java/org/moditect/spi/log/Log.java
+++ b/core/src/main/java/org/moditect/spi/log/Log.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.spi.log;
 

--- a/core/src/main/java/org/moditect/spi/log/Log.java
+++ b/core/src/main/java/org/moditect/spi/log/Log.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.spi.log;
 

--- a/core/src/test/java/org/moditect/internal/parser/JavaVersionHelperTest.java
+++ b/core/src/test/java/org/moditect/internal/parser/JavaVersionHelperTest.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.parser;
 

--- a/core/src/test/java/org/moditect/internal/parser/JavaVersionHelperTest.java
+++ b/core/src/test/java/org/moditect/internal/parser/JavaVersionHelperTest.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.internal.parser;
 

--- a/core/src/test/java/org/moditect/test/AddModuleInfoTest.java
+++ b/core/src/test/java/org/moditect/test/AddModuleInfoTest.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.test;
 

--- a/core/src/test/java/org/moditect/test/AddModuleInfoTest.java
+++ b/core/src/test/java/org/moditect/test/AddModuleInfoTest.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.test;
 

--- a/core/src/test/java/org/moditect/test/model/DependencePatternTest.java
+++ b/core/src/test/java/org/moditect/test/model/DependencePatternTest.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.test.model;
 

--- a/core/src/test/java/org/moditect/test/model/DependencePatternTest.java
+++ b/core/src/test/java/org/moditect/test/model/DependencePatternTest.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.test.model;
 

--- a/core/src/test/java/org/moditect/test/model/PackageNamePatternTest.java
+++ b/core/src/test/java/org/moditect/test/model/PackageNamePatternTest.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.test.model;
 

--- a/core/src/test/java/org/moditect/test/model/PackageNamePatternTest.java
+++ b/core/src/test/java/org/moditect/test/model/PackageNamePatternTest.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.test.model;
 

--- a/etc/eclipse-formatter-config.xml
+++ b/etc/eclipse-formatter-config.xml
@@ -1,23 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    SPDX-License-Identifier: Apache-2.0
+     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2021-2023 The ModiTect authors.
+      Copyright The original authors
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        https://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+
 <profiles version="12">
     <profile kind="CodeFormatterProfile" name="Debezium" version="12">
         <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>

--- a/etc/license.txt
+++ b/etc/license.txt
@@ -1,13 +1,5 @@
- Copyright 2017 - 2023 The ModiTect authors
+ SPDX-License-Identifier: Apache-2.0
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Copyright The original authors
 
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/etc/license.txt
+++ b/etc/license.txt
@@ -1,5 +1,5 @@
  SPDX-License-Identifier: Apache-2.0
 
-  Copyright The original authors
+ Copyright The original authors
 
-  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/integrationtest/hibernate-validator/pom.xml
+++ b/integrationtest/hibernate-validator/pom.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrationtest/hibernate-validator/pom.xml
+++ b/integrationtest/hibernate-validator/pom.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrationtest/hibernate-validator/src/main/java/com/example/ValidationTest.java
+++ b/integrationtest/hibernate-validator/src/main/java/com/example/ValidationTest.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/integrationtest/hibernate-validator/src/main/java/com/example/ValidationTest.java
+++ b/integrationtest/hibernate-validator/src/main/java/com/example/ValidationTest.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrationtest/undertow/pom.xml
+++ b/integrationtest/undertow/pom.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrationtest/undertow/pom.xml
+++ b/integrationtest/undertow/pom.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -74,13 +66,6 @@
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <header>${basedir}/../../etc/license.txt</header>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>

--- a/integrationtest/undertow/src/main/docker/Dockerfile
+++ b/integrationtest/undertow/src/main/docker/Dockerfile
@@ -1,17 +1,9 @@
 #
-#  Copyright 2017 - 2023 The ModiTect authors
+#  SPDX-License-Identifier: Apache-2.0
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+#   Copyright The original authors
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 FROM centos:7

--- a/integrationtest/undertow/src/main/docker/Dockerfile
+++ b/integrationtest/undertow/src/main/docker/Dockerfile
@@ -1,9 +1,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#   Copyright The original authors
+#  Copyright The original authors
 #
-#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 FROM centos:7

--- a/integrationtest/undertow/src/main/docker/assembly.xml
+++ b/integrationtest/undertow/src/main/docker/assembly.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"

--- a/integrationtest/undertow/src/main/docker/assembly.xml
+++ b/integrationtest/undertow/src/main/docker/assembly.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"

--- a/integrationtest/undertow/src/main/docker/entrypoint.sh
+++ b/integrationtest/undertow/src/main/docker/entrypoint.sh
@@ -2,9 +2,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#   Copyright The original authors
+#  Copyright The original authors
 #
-#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 set -e

--- a/integrationtest/undertow/src/main/docker/entrypoint.sh
+++ b/integrationtest/undertow/src/main/docker/entrypoint.sh
@@ -1,18 +1,10 @@
 #!/bin/bash
 #
-#  Copyright 2017 - 2023 The ModiTect authors
+#  SPDX-License-Identifier: Apache-2.0
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+#   Copyright The original authors
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 set -e

--- a/integrationtest/undertow/src/main/java/com/example/HelloWorldServer.java
+++ b/integrationtest/undertow/src/main/java/com/example/HelloWorldServer.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/integrationtest/undertow/src/main/java/com/example/HelloWorldServer.java
+++ b/integrationtest/undertow/src/main/java/com/example/HelloWorldServer.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/integrationtest/vert.x/pom.xml
+++ b/integrationtest/vert.x/pom.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrationtest/vert.x/pom.xml
+++ b/integrationtest/vert.x/pom.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrationtest/vert.x/src/main/docker-base/Dockerfile
+++ b/integrationtest/vert.x/src/main/docker-base/Dockerfile
@@ -1,17 +1,9 @@
 #
-#  Copyright 2017 - 2023 The ModiTect authors
+#  SPDX-License-Identifier: Apache-2.0
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+#   Copyright The original authors
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 FROM centos:7

--- a/integrationtest/vert.x/src/main/docker-base/Dockerfile
+++ b/integrationtest/vert.x/src/main/docker-base/Dockerfile
@@ -1,9 +1,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#   Copyright The original authors
+#  Copyright The original authors
 #
-#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 FROM centos:7

--- a/integrationtest/vert.x/src/main/docker-base/entrypoint.sh
+++ b/integrationtest/vert.x/src/main/docker-base/entrypoint.sh
@@ -2,9 +2,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#   Copyright The original authors
+#  Copyright The original authors
 #
-#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 set -e

--- a/integrationtest/vert.x/src/main/docker-base/entrypoint.sh
+++ b/integrationtest/vert.x/src/main/docker-base/entrypoint.sh
@@ -1,18 +1,10 @@
 #!/bin/bash
 #
-#  Copyright 2017 - 2023 The ModiTect authors
+#  SPDX-License-Identifier: Apache-2.0
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+#   Copyright The original authors
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 set -e

--- a/integrationtest/vert.x/src/main/docker/Dockerfile
+++ b/integrationtest/vert.x/src/main/docker/Dockerfile
@@ -1,9 +1,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#   Copyright The original authors
+#  Copyright The original authors
 #
-#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 FROM moditect/vertx-helloworld-base

--- a/integrationtest/vert.x/src/main/docker/Dockerfile
+++ b/integrationtest/vert.x/src/main/docker/Dockerfile
@@ -1,17 +1,9 @@
 #
-#  Copyright 2017 - 2023 The ModiTect authors
+#  SPDX-License-Identifier: Apache-2.0
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+#   Copyright The original authors
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 FROM moditect/vertx-helloworld-base

--- a/integrationtest/vert.x/src/main/docker/assembly-base.xml
+++ b/integrationtest/vert.x/src/main/docker/assembly-base.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"

--- a/integrationtest/vert.x/src/main/docker/assembly-base.xml
+++ b/integrationtest/vert.x/src/main/docker/assembly-base.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"

--- a/integrationtest/vert.x/src/main/docker/assembly.xml
+++ b/integrationtest/vert.x/src/main/docker/assembly.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"

--- a/integrationtest/vert.x/src/main/docker/assembly.xml
+++ b/integrationtest/vert.x/src/main/docker/assembly.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"

--- a/integrationtest/vert.x/src/main/docker/helloWorld.sh
+++ b/integrationtest/vert.x/src/main/docker/helloWorld.sh
@@ -2,9 +2,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#   Copyright The original authors
+#  Copyright The original authors
 #
-#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 DIR=`dirname $0`

--- a/integrationtest/vert.x/src/main/docker/helloWorld.sh
+++ b/integrationtest/vert.x/src/main/docker/helloWorld.sh
@@ -1,18 +1,10 @@
 #!/bin/sh
 #
-#  Copyright 2017 - 2023 The ModiTect authors
+#  SPDX-License-Identifier: Apache-2.0
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+#   Copyright The original authors
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+#   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
 DIR=`dirname $0`

--- a/integrationtest/vert.x/src/main/java/com/example/HelloWorldServer.java
+++ b/integrationtest/vert.x/src/main/java/com/example/HelloWorldServer.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/integrationtest/vert.x/src/main/java/com/example/HelloWorldServer.java
+++ b/integrationtest/vert.x/src/main/java/com/example/HelloWorldServer.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/integrationtest/vert.x/src/main/java/com/example/HelloWorldVerticle.java
+++ b/integrationtest/vert.x/src/main/java/com/example/HelloWorldVerticle.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/integrationtest/vert.x/src/main/java/com/example/HelloWorldVerticle.java
+++ b/integrationtest/vert.x/src/main/java/com/example/HelloWorldVerticle.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.example;
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,18 +1,10 @@
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -33,17 +33,17 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>3.5.0</version>
+                <version>4.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-annotations</artifactId>
-                <version>2.1.1</version>
+                <version>2.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-classworlds</artifactId>
-                <version>2.7.0</version>
+                <version>2.8.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.8.1</version>
+            <version>3.11.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -2,9 +2,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.add;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/AddModuleInfoMojo.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.add;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/MainModuleConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/MainModuleConfiguration.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.add.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/MainModuleConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/MainModuleConfiguration.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.add.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/ModuleConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/ModuleConfiguration.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.add.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/ModuleConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/add/model/ModuleConfiguration.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.add.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ArtifactConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ArtifactConfiguration.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.common.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ArtifactConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ArtifactConfiguration.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.common.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ModuleInfoConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ModuleInfoConfiguration.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.common.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ModuleInfoConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/common/model/ModuleInfoConfiguration.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.common.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/CompileScopeDependencySelector.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/CompileScopeDependencySelector.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/CompileScopeDependencySelector.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/CompileScopeDependencySelector.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/GenerateModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/GenerateModuleInfoMojo.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/GenerateModuleInfoMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/GenerateModuleInfoMojo.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/ModuleInfoGenerator.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/ModuleInfoGenerator.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/ModuleInfoGenerator.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/ModuleInfoGenerator.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ArtifactIdentifier.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ArtifactIdentifier.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ArtifactIdentifier.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ArtifactIdentifier.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ModuleConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ModuleConfiguration.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ModuleConfiguration.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/generate/model/ModuleConfiguration.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.generate.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.image;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.image;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/model/Launcher.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/model/Launcher.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.image.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/model/Launcher.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/model/Launcher.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.image.model;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/modulelist/GenerateModuleListMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/modulelist/GenerateModuleListMojo.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.modulelist;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/modulelist/GenerateModuleListMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/modulelist/GenerateModuleListMojo.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.modulelist;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/util/ArtifactResolutionHelper.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/util/ArtifactResolutionHelper.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.util;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/util/ArtifactResolutionHelper.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/util/ArtifactResolutionHelper.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.util;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/util/DependencyHelper.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/util/DependencyHelper.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.util;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/util/DependencyHelper.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/util/DependencyHelper.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.util;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/util/MojoLog.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/util/MojoLog.java
@@ -1,17 +1,9 @@
 /*
- *  Copyright 2017 - 2023 The ModiTect authors
+ *  SPDX-License-Identifier: Apache-2.0
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *   Copyright The original authors
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.util;
 

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/util/MojoLog.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/util/MojoLog.java
@@ -1,9 +1,9 @@
 /*
  *  SPDX-License-Identifier: Apache-2.0
  *
- *   Copyright The original authors
+ *  Copyright The original authors
  *
- *   Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.moditect.mavenplugin.util;
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -3,9 +3,9 @@
 
      SPDX-License-Identifier: Apache-2.0
 
-      Copyright The original authors
+     Copyright The original authors
 
-      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,19 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017 - 2023 The ModiTect authors
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -148,16 +140,20 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration combine.self="override">
-                    <header>${maven.multiModuleProjectDirectory}/etc/license.txt</header>
                     <strictCheck>true</strictCheck>
-                    <excludes>
-                        <exclude>README.md</exclude>
-                        <exclude>LICENSE.txt</exclude>
-                        <exclude>mvnw</exclude>
-                        <exclude>mvnw.cmd</exclude>
-                        <exclude>.mvn/wrapper/maven-wrapper.properties</exclude>
-                        <exclude>.mvn/wrapper/MavenWrapperDownloader.java</exclude>
-                    </excludes>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>${maven.multiModuleProjectDirectory}/etc/license.txt</header>
+                            <excludes>
+                                <exclude>README.md</exclude>
+                                <exclude>LICENSE.txt</exclude>
+                                <exclude>mvnw</exclude>
+                                <exclude>mvnw.cmd</exclude>
+                                <exclude>.mvn/wrapper/maven-wrapper.properties</exclude>
+                                <exclude>.mvn/wrapper/MavenWrapperDownloader.java</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
                 <executions>
                     <execution>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,10 +34,10 @@
         <project.repository>moditect/moditect</project.repository>
         <local.repository.path>/tmp/repository</local.repository.path>
         <java.version>1.8</java.version>
-        <maven.version>3.8.7</maven.version>
+        <maven.version>3.9.6</maven.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <version.surefire.plugin>3.0.0-M4</version.surefire.plugin>
+        <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <!-- value comes from property git.commit.author.time -->
         <project.build.outputTimestamp>${git.commit.author.time}</project.build.outputTimestamp>
     </properties>
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-core</artifactId>
-                <version>3.25.1</version>
+                <version>3.25.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.testing.compile</groupId>
@@ -75,17 +75,17 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.31.0</version>
+                <version>3.42.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.1-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.18.0</version>
+                <version>2.26.1</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
@@ -95,7 +95,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.24.2</version>
+                <version>3.25.3</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.36</version>
+                <version>2.0.12</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -116,17 +116,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.11.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,22 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-     Copyright 2017 Gunnar Morling (http://www.gunnarmorling.de/)
-     and/or other contributors as indicated by the @authors tag. See the
-     copyright.txt file in the distribution for a full listing of all
-     contributors.
+     SPDX-License-Identifier: Apache-2.0
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+      Copyright The original authors
 
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+      Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"


### PR DESCRIPTION
fixes #241
Update license to remove year and apply it to existing files
Update Maven version to 3.9.6
Update Maven dependencies and plugin to last non-breaking version