### PR TITLE
Coping with non-unique dependency jar names

### DIFF
--- a/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
+++ b/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.moditect.internal.command.ProcessExecutor;
 import org.moditect.model.DependencyJar;
+import org.moditect.model.DependencyJar.FileCopy;
 import org.moditect.model.JarInclusionPolicy;
 import org.moditect.spi.log.Log;
 
@@ -133,10 +134,9 @@ public class CreateRuntimeImage {
     private void copyDependencyJars(Path jarDirectory) throws IOException {
         log.info("Copying project dependencies");
 
-        for (DependencyJar dependency : dependencies) {
-            Path target = jarDirectory.resolve(dependency.jarPath().getFileName());
-            Files.copy(dependency.jarPath(), target);
-            log.debug(String.format("Done copying dependency %s to %s", dependency, target));
+        for (FileCopy fc : DependencyJar.uniqueDestinations(jarDirectory, dependencies)) {
+            Files.copy(fc.source(), fc.sink());
+            log.debug(String.format("Done copying dependency %s to %s", fc.source(), fc.sink()));
         }
 
         log.info("Done copying project dependencies");

--- a/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
+++ b/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.moditect.internal.command.ProcessExecutor;
+import org.moditect.model.DependencyJar;
 import org.moditect.model.JarInclusionPolicy;
 import org.moditect.spi.log.Log;
 
@@ -36,7 +37,7 @@ public class CreateRuntimeImage {
     private final Set<Path> modulePath;
     private final List<String> modules;
     private final JarInclusionPolicy jarInclusionPolicy;
-    private final Set<Path> dependencies;
+    private final Set<DependencyJar> dependencies;
     private final Path projectJar;
     private final Path outputDirectory;
     private boolean ignoreSigningInformation;
@@ -50,7 +51,7 @@ public class CreateRuntimeImage {
     private final boolean bindServices;
 
     public CreateRuntimeImage(Set<Path> modulePath, List<String> modules, JarInclusionPolicy jarInclusionPolicy,
-                              Set<Path> dependencies, Path projectJar, String launcherName, String launcherModule,
+                              Set<DependencyJar> dependencies, Path projectJar, String launcherName, String launcherModule,
                               Path outputDirectory, String compression, boolean stripDebug,
                               boolean ignoreSigningInformation, List<String> excludeResourcesPatterns, Log log,
                               boolean noHeaderFiles, boolean noManPages, boolean bindServices) {
@@ -132,9 +133,9 @@ public class CreateRuntimeImage {
     private void copyDependencyJars(Path jarDirectory) throws IOException {
         log.info("Copying project dependencies");
 
-        for (Path dependency : dependencies) {
-            Path target = jarDirectory.resolve(dependency.getFileName());
-            Files.copy(dependency, target);
+        for (DependencyJar dependency : dependencies) {
+            Path target = jarDirectory.resolve(dependency.jarPath().getFileName());
+            Files.copy(dependency.jarPath(), target);
             log.debug(String.format("Done copying dependency %s to %s", dependency, target));
         }
 

--- a/core/src/main/java/org/moditect/commands/GenerateModuleList.java
+++ b/core/src/main/java/org/moditect/commands/GenerateModuleList.java
@@ -18,19 +18,20 @@ import java.util.spi.ToolProvider;
 import java.util.stream.Collectors;
 
 import org.moditect.internal.command.LogWriter;
+import org.moditect.model.DependencyJar;
 import org.moditect.model.Version;
 import org.moditect.spi.log.Log;
 
 public class GenerateModuleList {
 
     private final Path projectJar;
-    private final Set<Path> dependencies;
+    private final Set<DependencyJar> dependencies;
     private final Version jvmVersion;
     private final Log log;
 
     private final ToolProvider jdeps;
 
-    public GenerateModuleList(Path projectJar, Set<Path> dependencies, Version jvmVersion, Log log) {
+    public GenerateModuleList(Path projectJar, Set<DependencyJar> dependencies, Version jvmVersion, Log log) {
         this.projectJar = projectJar;
         this.dependencies = dependencies;
         this.jvmVersion = jvmVersion;
@@ -61,6 +62,7 @@ public class GenerateModuleList {
         command.add(String.valueOf(jvmVersion.feature()));
         command.add("--class-path");
         String classPath = dependencies.stream()
+                .map(DependencyJar::jarPath)
                 .map(Path::toAbsolutePath)
                 .map(Path::toString)
                 .collect(Collectors.joining(File.pathSeparator));

--- a/core/src/main/java/org/moditect/model/DependencyJar.java
+++ b/core/src/main/java/org/moditect/model/DependencyJar.java
@@ -1,0 +1,41 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.moditect.model;
+
+import java.nio.file.Path;
+
+public class DependencyJar {
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+    private final Path jarPath;
+
+    public DependencyJar(String groupId, String artifactId, String version, Path jarPath) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.jarPath = jarPath;
+    }
+
+    public String groupId() {
+        return groupId;
+    }
+
+    public String artifactId() {
+        return artifactId;
+    }
+
+    public String version() {
+        return version;
+    }
+
+    public Path jarPath() {
+        return jarPath;
+    }
+}

--- a/core/src/main/java/org/moditect/model/DependencyJar.java
+++ b/core/src/main/java/org/moditect/model/DependencyJar.java
@@ -8,6 +8,13 @@
 package org.moditect.model;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public class DependencyJar {
 
@@ -37,5 +44,56 @@ public class DependencyJar {
 
     public Path jarPath() {
         return jarPath;
+    }
+
+    /**
+     * Copes with non-unique dependency jar filenames by selectively prepending the groupId.
+     * @param destDir The directory where we want to deposit the dependency jars
+     * @param dependencies The set of dependencies that we want to deposit
+     * @return A list of file copy operations
+     */
+    public static List<FileCopy> uniqueDestinations(Path destDir, Set<DependencyJar> dependencies) {
+        Set<Path> nonUniqueJarNames = dependencies.stream()
+                .map(dj -> dj.jarPath().getFileName())
+                .collect(Collectors.toMap(
+                        k -> k,
+                        v -> 1,
+                        (a, b) -> a + b))
+                .entrySet().stream()
+                .filter(e -> e.getValue() > 1)
+                .map(Entry::getKey)
+                .collect(toSet());
+
+        return dependencies.stream()
+                .map(d -> {
+                    Path sink;
+                    if (nonUniqueJarNames.contains(d.jarPath().getFileName())) {
+                        sink = destDir.resolve(
+                                d.groupId() + "." + d.jarPath().getFileName().toString());
+                    }
+                    else {
+                        sink = destDir.resolve(d.jarPath().getFileName());
+                    }
+                    return new FileCopy(d.jarPath(), sink);
+                })
+                .collect(toList());
+    }
+
+    public static class FileCopy {
+        private final Path source;
+        private final Path sink;
+
+        public FileCopy(Path source, Path sink) {
+            this.source = source;
+            this.sink = sink;
+        }
+
+        public Path source() {
+            return source;
+        }
+
+        public Path sink() {
+            return sink;
+        }
     }
 }

--- a/core/src/test/java/org/moditect/model/DependencyJarTest.java
+++ b/core/src/test/java/org/moditect/model/DependencyJarTest.java
@@ -1,0 +1,58 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Copyright The original authors
+ *
+ *  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.moditect.model;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.moditect.model.DependencyJar.FileCopy;
+
+import junit.framework.TestCase;
+
+/**
+ * Exercises {@link DependencyJar}
+ */
+public class DependencyJarTest extends TestCase {
+
+    /**
+     * Demonstrates the behaviour of {@link DependencyJar#uniqueDestinations(Path, Set)}:
+     * <ul>
+     *   <li>unique dependency jar names are copied directly</li>
+     *   <li>non-unique jar names are disambiguated by prepending the groupId</li>
+     * </ul>
+     */
+    @Test
+    public void testUniqueDestinations() {
+        Set<DependencyJar> deps = new HashSet<>(Arrays.asList(
+                new DependencyJar("ga", "aa", "va", Paths.get("ga/aa-va.jar")),
+                new DependencyJar("gr1", "ar", "vr", Paths.get("gr1/ar-vr.jar")),
+                new DependencyJar("gb", "ab", "vb", Paths.get("gb/ab-vb.jar")),
+                new DependencyJar("gr2", "ar", "vr", Paths.get("gr2/ar-vr.jar")),
+                new DependencyJar("gc", "ac", "vc", Paths.get("gc/ac-vc.jar"))));
+
+        List<FileCopy> copies = DependencyJar.uniqueDestinations(Paths.get("dst"), deps);
+
+        Assert.assertEquals(""
+                + "ga/aa-va.jar -> dst/aa-va.jar\n"
+                + "gb/ab-vb.jar -> dst/ab-vb.jar\n"
+                + "gc/ac-vc.jar -> dst/ac-vc.jar\n"
+                + "gr1/ar-vr.jar -> dst/gr1.ar-vr.jar\n"
+                + "gr2/ar-vr.jar -> dst/gr2.ar-vr.jar",
+                copies.stream()
+                        .map(fc -> fc.source() + " -> " + fc.sink())
+                        .sorted()
+                        .collect(Collectors.joining("\n")));
+    }
+}

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/util/DependencyHelper.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/util/DependencyHelper.java
@@ -7,18 +7,22 @@
  */
 package org.moditect.mavenplugin.util;
 
-import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.project.MavenProject;
+import org.moditect.model.DependencyJar;
 
 public class DependencyHelper {
 
-    public static Set<Path> getDirectAndTransitiveDependencies(MavenProject project) {
+    public static Set<DependencyJar> getDirectAndTransitiveDependencies(MavenProject project) {
         return project.getArtifacts()
                 .stream()
-                .map(a -> a.getFile().toPath())
+                .map(a -> new DependencyJar(
+                        a.getGroupId(),
+                        a.getArtifactId(),
+                        a.getVersion(),
+                        a.getFile().toPath()))
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
There's no guarantee that the `artifactId`+`version` of a dependency is unique, so `CreateRuntimeImage`'s dependency inclusion behaviour of copying jars into a single directory is failure-prone: projects with dependencies that differ only by their `groupId` will provoke a `java.nio.file.FileAlreadyExistsException`.

This change will detect such cases and prepend the `groupId` to the destination jar name.

A related problem also exists in `AddModuleInfo` - ideally it'd have an option akin to `dependency:copy`'s [`prependGroupId`](https://maven.apache.org/plugins/maven-dependency-plugin/copy-mojo.html#prependGroupId)