### PR TITLE
Add support for VM options via addOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ _create-runtime-image_ goal as follows:
                     ${project.build.directory}/jlink-image
                 </outputDirectory>
                 <addOptions>
-                    <option>--some-vm-option</option>
+                    <addOption>--some-vm-option</addOption>
                 </addOptions>
             </configuration>
         </execution>

--- a/README.md
+++ b/README.md
@@ -375,6 +375,9 @@ _create-runtime-image_ goal as follows:
                 <outputDirectory>
                     ${project.build.directory}/jlink-image
                 </outputDirectory>
+                <addOptions>
+                    <option>--some-vm-option</option>
+                </addOptions>
             </configuration>
         </execution>
     </executions>
@@ -408,6 +411,8 @@ to the runtime image.
 * `jarInclusionPolicy`: Whether to add the application JAR and optionally its dependencies
 to the runtime image, under the _jars_ directory, allowing to run a classpath-based
 application on a modular runtime image; allowed values are `NONE`, `APP`, and `APP_WITH_DEPENDENCIES`.
+* `addOptions`: Provide a list of VM options. These options will be appended to the end of the 
+`jlink` command as `--add-options="<option 1> <option 2> ... <option n>"`
 
 In order to identify the JDK images which should go into a custom runtime image for a classpath-based application,
 you can run the following goal:

--- a/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
+++ b/core/src/main/java/org/moditect/commands/CreateRuntimeImage.java
@@ -48,12 +48,13 @@ public class CreateRuntimeImage {
     private final boolean noManPages;
     private final List<String> excludeResourcesPatterns;
     private final boolean bindServices;
+    private final List<String> options;
 
     public CreateRuntimeImage(Set<Path> modulePath, List<String> modules, JarInclusionPolicy jarInclusionPolicy,
                               Set<Path> dependencies, Path projectJar, String launcherName, String launcherModule,
                               Path outputDirectory, String compression, boolean stripDebug,
                               boolean ignoreSigningInformation, List<String> excludeResourcesPatterns, Log log,
-                              boolean noHeaderFiles, boolean noManPages, boolean bindServices) {
+                              boolean noHeaderFiles, boolean noManPages, boolean bindServices, List<String> options) {
         this.modulePath = (modulePath != null ? modulePath : Collections.emptySet());
         this.modules = getModules(modules);
         this.jarInclusionPolicy = jarInclusionPolicy;
@@ -69,6 +70,7 @@ public class CreateRuntimeImage {
         this.noHeaderFiles = noHeaderFiles;
         this.noManPages = noManPages;
         this.bindServices = bindServices;
+        this.options = options;
     }
 
     private static List<String> getModules(List<String> modules) {
@@ -192,6 +194,10 @@ public class CreateRuntimeImage {
 
         if (bindServices) {
             command.add("--bind-services");
+        }
+
+        if (options != null && !options.isEmpty()) {
+            command.add("--add-options=\"" + String.join(" ", options) + "\"");
         }
 
         log.debug("Running jlink: " + String.join(" ", command));

--- a/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
+++ b/maven-plugin/src/main/java/org/moditect/mavenplugin/image/CreateRuntimeImageMojo.java
@@ -102,6 +102,9 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean bindServices;
 
+    @Parameter
+    private List<String> addOptions;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Path jmodsDir = getJModsDir();
@@ -134,7 +137,8 @@ public class CreateRuntimeImageMojo extends AbstractMojo {
                 new MojoLog(getLog()),
                 noHeaderFiles,
                 noManPages,
-                bindServices);
+                bindServices,
+                addOptions);
         try {
             createRuntimeImage.run();
         }


### PR DESCRIPTION
This PR adds support for adding VM options via a new `addOptions` configuration property.

The naming convention mirrors that of the [apache-jlink-plugin](https://maven.apache.org/plugins/maven-jlink-plugin/jlink-mojo.html#addOptions)

The following configuration:
```
...
<addOptions>
    <addOption>-Xmx256m</addOption>
    <addOption>--enable-preview</addOption>
    <addOption>-Dvar=value</addOption>
</addOptions>
...
```

will append the following to the `jlink` command:
```
--add-options="-Xmx256m --enable-preview -Dvar=value"
```

My particular use case for this was to allow JavaFX to have native access via `--enable-native-access=javafx.graphics`.  As of Java 25, the JVM logs a warning that this option will be explicitly required in the future, so I think it would be nice to support the option:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.glass.utils.NativeLibLoader in module javafx.graphics (jrt:/javafx.graphics)
WARNING: Use --enable-native-access=javafx.graphics to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

Great project btw :+1: